### PR TITLE
feature: Defensive copying, eslint errors

### DIFF
--- a/src/utils/fee/index.ts
+++ b/src/utils/fee/index.ts
@@ -52,13 +52,13 @@ export const getStakingTxInputUTXOsAndFees = (
     throw new Error("Insufficient funds");
   }
   // Sort available UTXOs from highest to lowest value
-  availableUTXOs.sort((a, b) => b.value - a.value);
+  const sortedUTXOs = [...availableUTXOs].sort((a, b) => b.value - a.value);
 
   const selectedUTXOs: UTXO[] = [];
   let accumulatedValue = 0;
   let estimatedFee;
 
-  for (const utxo of availableUTXOs) {
+  for (const utxo of sortedUTXOs) {
     selectedUTXOs.push(utxo);
     accumulatedValue += utxo.value;
 

--- a/src/utils/fee/utils.ts
+++ b/src/utils/fee/utils.ts
@@ -29,6 +29,7 @@ export const getInputSizeByScript = (script: Buffer): number => {
     if (p2wpkhAddress) {
       return P2WPKH_INPUT_SIZE;
     }
+    // eslint-disable-next-line no-empty
   } catch (error) {} // Ignore errors
   // Check if input is in the format of "51 <32-byte public key>"
   // If yes, it is a P2TR input
@@ -39,6 +40,7 @@ export const getInputSizeByScript = (script: Buffer): number => {
     if (p2trAddress) {
       return P2TR_INPUT_SIZE;
     }
+    // eslint-disable-next-line no-empty
   } catch (error) {} // Ignore errors
   // Otherwise, assume the input is largest P2PKH address type
   return DEFAULT_INPUT_SIZE;

--- a/src/utils/stakingScript.ts
+++ b/src/utils/stakingScript.ts
@@ -328,7 +328,7 @@ export class StakingScriptData {
       return this.#buildSingleKeyScript(pks[0], withVerify);
     }
     // keys must be sorted
-    const sortedPks = pks.sort(Buffer.compare);
+    const sortedPks = [...pks].sort(Buffer.compare);
     // verify there are no duplicates
     for (let i = 0; i < sortedPks.length - 1; ++i) {
       if (sortedPks[i].equals(sortedPks[i + 1])) {

--- a/tests/utils/fee/stakingtxFee.test.ts
+++ b/tests/utils/fee/stakingtxFee.test.ts
@@ -62,9 +62,9 @@ testingNetworks.forEach(({ networkName, network, dataGenerator }) => {
         availableUTXOs.length,
       );
       // Ensure the highest value UTXOs are selected
-      availableUTXOs.sort((a, b) => b.value - a.value);
+      const sortedUTXOs = [...availableUTXOs].sort((a, b) => b.value - a.value);
       expect(result.selectedUTXOs).toEqual(
-        availableUTXOs.slice(0, result.selectedUTXOs.length),
+        sortedUTXOs.slice(0, result.selectedUTXOs.length),
       );
       expect(result.fee).toBeGreaterThan(0);
     });

--- a/tests/utils/fee/stakingtxFee.test.ts
+++ b/tests/utils/fee/stakingtxFee.test.ts
@@ -144,7 +144,7 @@ testingNetworks.forEach(({ networkName, network, dataGenerator }) => {
       ];
 
       const outputs = buildStakingOutput(mockScripts, network, stakeAmount);
-      let result = getStakingTxInputUTXOsAndFees(
+      const result = getStakingTxInputUTXOsAndFees(
         network,
         availableUTXOs,
         stakeAmount,
@@ -176,7 +176,7 @@ testingNetworks.forEach(({ networkName, network, dataGenerator }) => {
       ];
 
       const outputs = buildStakingOutput(mockScripts, network, stakeAmount);
-      let result = getStakingTxInputUTXOsAndFees(
+      const result = getStakingTxInputUTXOsAndFees(
         network,
         availableUTXOs,
         stakeAmount,
@@ -208,7 +208,7 @@ testingNetworks.forEach(({ networkName, network, dataGenerator }) => {
       ];
 
       const outputs = buildStakingOutput(mockScripts, network, stakeAmount);
-      let result = getStakingTxInputUTXOsAndFees(
+      const result = getStakingTxInputUTXOsAndFees(
         network,
         availableUTXOs,
         stakeAmount,

--- a/tests/utils/stakingScript.test.ts
+++ b/tests/utils/stakingScript.test.ts
@@ -314,7 +314,7 @@ describe("stakingScript", () => {
         magicBytes,
       );
 
-      const sortedPks = pks.sort(Buffer.compare);
+      const sortedPks = [...pks].sort(Buffer.compare);
 
       const unbondingScript = stakingScriptData.buildUnbondingScript();
       const decompiled = script.decompile(unbondingScript);
@@ -350,7 +350,7 @@ describe("stakingScript", () => {
         magicBytes,
       );
 
-      const sortedPks = pks.sort(Buffer.compare);
+      const sortedPks = [...pks].sort(Buffer.compare);
 
       const slashingScript = stakingScriptData.buildSlashingScript();
       const decompiled = script.decompile(slashingScript);


### PR DESCRIPTION
This PR:

1. Applies defensive copying when we use `.sort`
2. Changes`let result` to `const result` since these variables are not changed or reassigned
3. Disables `eslint` rules for 2 lines where we do not deal with errors `eslint-disable-next-line no-empty`

Closes #4 