### PR TITLE
fix: cicd shall use npm ci to use locked dependency versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: '21.7'
       - run:
           name: Install requirements
-          command: npm install
+          command: npm ci
       - run:
           name: Run tests
           command: npm run test
@@ -26,7 +26,7 @@ jobs:
           node-version: '21.7'
       - run:
           name: Install requirements
-          command: npm install
+          command: npm ci
       - run:
           name: Authenticate with NPM registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
@@ -59,7 +59,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:
           name: Install requirements
-          command: npm install
+          command: npm ci
       - run:
           name: Publish package
           command: npm publish


### PR DESCRIPTION
No version bump is required as this is a CICD change only