### PR TITLE
fix: revert peerDependency to fix the broken build

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { build } from "esbuild";
 import { readFile } from "fs/promises";
 import path from "path";
@@ -17,6 +18,7 @@ async function main() {
     ...shared,
     platform: "node", // for CJS
     outfile: "dist/index.cjs",
+    format: "cjs",
   });
 
   await build({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "0.3.0-canary.9",
+  "version": "0.3.0-canary.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/btc-staking-ts",
-      "version": "0.3.0-canary.9",
+      "version": "0.3.0-canary.10",
       "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
+        "bitcoinjs-lib": "6.1.5"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.30",
@@ -26,11 +30,7 @@
         "typescript-eslint": "^7.4.0"
       },
       "engines": {
-        "node": "22.7.0"
-      },
-      "peerDependencies": {
-        "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
-        "bitcoinjs-lib": "6.1.5"
+        "node": "22.3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -634,7 +634,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@bitcoin-js/tiny-secp256k1-asmjs/-/tiny-secp256k1-asmjs-2.2.3.tgz",
       "integrity": "sha512-arFPdEZi9RIiaG76OZswTnAU0KfuiLwGw2VNfD66LKhzlbfOnX1o1WI/GI3qm9UbjG/0QOzZu/KmTNvL79x/DQ==",
-      "peer": true,
       "dependencies": {
         "uint8array-tools": "0.0.7"
       },
@@ -1185,7 +1184,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -1887,20 +1885,17 @@
     "node_modules/base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
-      "peer": true
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "peer": true
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/bip174": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
       "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1910,7 +1905,6 @@
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.5.tgz",
       "integrity": "sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
@@ -1994,7 +1988,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "peer": true,
       "dependencies": {
         "base-x": "^4.0.0"
       }
@@ -2003,7 +1996,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
       "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^5.0.0"
@@ -5785,7 +5777,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
       "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5860,7 +5851,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
       "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "0.3.0-canary.9",
+  "version": "0.3.0-canary.10",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol.",
   "module": "dist/index.js",
   "main": "dist/index.cjs",
@@ -63,7 +63,7 @@
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.4.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "bitcoinjs-lib": "6.1.5"
   },


### PR DESCRIPTION
You can try host on local using `npm link`, revert the peerDependency no longer produce the issue.
I'm not certain the exact root cause, but since the `peerDependency` vs `dependency` is a good to have thing, i would prefer to revert it now and get the rest of code audited while we continue investigate and have it fixed later on 