### PR TITLE
fix: staking tx should not be RBFable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "0.4.0-canary.3",
+  "version": "0.4.0-canary.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/btc-staking-ts",
-      "version": "0.4.0-canary.3",
+      "version": "0.4.0-canary.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "0.4.0-canary.3",
+  "version": "0.4.0-canary.4",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol.",
   "module": "dist/index.js",
   "main": "dist/index.cjs",

--- a/src/staking/transactions.ts
+++ b/src/staking/transactions.ts
@@ -9,7 +9,7 @@ import { isValidBitcoinAddress, transactionIdToHash } from "../utils/btc";
 import { getStakingTxInputUTXOsAndFees, getWithdrawTxFee } from "../utils/fee";
 import { inputValueSum } from "../utils/fee/utils";
 import { buildStakingTransactionOutputs } from "../utils/staking";
-import { NON_RBF_SEQUENCE, TRANSACTION_VERSION, RBF_SEQUENCE } from "../constants/psbt";
+import { NON_RBF_SEQUENCE, TRANSACTION_VERSION } from "../constants/psbt";
 import { CovenantSignature } from "../types/covenantSignatures";
 import { REDEEM_VERSION } from "../constants/transaction";
 
@@ -92,7 +92,7 @@ export function stakingTransaction(
     tx.addInput(
       transactionIdToHash(input.txid),
       input.vout,
-      RBF_SEQUENCE,
+      NON_RBF_SEQUENCE,
     );
   }
 

--- a/tests/staking/createStakingTx.test.ts
+++ b/tests/staking/createStakingTx.test.ts
@@ -5,7 +5,7 @@ import { StakingParams } from "../../src/types/params";
 import { UTXO } from "../../src/types/UTXO";
 import { StakingError, StakingErrorCode } from "../../src/error";
 import { BTC_DUST_SAT } from "../../src/constants/dustSat";
-import { RBF_SEQUENCE } from "../../src/constants/psbt";
+import { NON_RBF_SEQUENCE } from "../../src/constants/psbt";
 import * as stakingUtils from "../../src/utils/staking";
 import * as stakingTx from "../../src/staking/transactions";
 import { Staking, transactionIdToHash } from "../../src";
@@ -154,8 +154,8 @@ describe.each(testingNetworks)("Create staking transaction", ({
     expect(psbt.data.inputs[0].witnessUtxo?.script.toString("hex")).toEqual(utxos[0].scriptPubKey);
 
     // Validate sequences
-    transaction.ins.forEach(input => expect(input.sequence).toBe(RBF_SEQUENCE));
-    psbt.txInputs.forEach(input => expect(input.sequence).toBe(RBF_SEQUENCE));
+    transaction.ins.forEach(input => expect(input.sequence).toBe(NON_RBF_SEQUENCE));
+    psbt.txInputs.forEach(input => expect(input.sequence).toBe(NON_RBF_SEQUENCE));
 
     // Calculate and validate amounts
     const psbtInputAmount = psbt.data.inputs.reduce((sum, input) => 

--- a/tests/staking/observable/createStakingTx.test.ts
+++ b/tests/staking/observable/createStakingTx.test.ts
@@ -6,7 +6,7 @@ import { ObservableStakingParams } from "../../../src/types/params";
 import { UTXO } from "../../../src/types/UTXO";
 import { StakingError, StakingErrorCode } from "../../../src/error";
 import { BTC_DUST_SAT } from "../../../src/constants/dustSat";
-import { RBF_SEQUENCE } from "../../../src/constants/psbt";
+import { NON_RBF_SEQUENCE } from "../../../src/constants/psbt";
 import * as stakingUtils from "../../../src/utils/staking";
 import * as staking from "../../../src/staking/transactions";
 
@@ -141,7 +141,7 @@ describe.each(testingNetworks)("Observal - Create staking transaction", ({
     expect(transaction.locktime).toBe(params.activationHeight - 1);
     expect(transaction.version).toBe(2);
     transaction.ins.map((input) => {
-      expect(input.sequence).toBe(RBF_SEQUENCE);
+      expect(input.sequence).toBe(NON_RBF_SEQUENCE);
     });
 
     // Check the data embed script(OP_RETURN)

--- a/tests/staking/psbt/stakingPsbt.test.ts
+++ b/tests/staking/psbt/stakingPsbt.test.ts
@@ -1,6 +1,6 @@
 import { address, Psbt } from "bitcoinjs-lib";
 import { BTC_DUST_SAT } from "../../../src/constants/dustSat";
-import { RBF_SEQUENCE } from "../../../src/constants/psbt";
+import { NON_RBF_SEQUENCE } from "../../../src/constants/psbt";
 import { StakingScripts, stakingTransaction } from "../../../src/index";
 import { ObservableStakingScripts } from "../../../src/staking/observable";
 import { DEFAULT_TEST_FEE_RATE, testingNetworks } from "../../helper";
@@ -176,7 +176,7 @@ describe.each(testingNetworks)("Transactions - ", (
     ).toBeDefined();
 
     psbt.txInputs.map((input) => {
-      expect(input.sequence).toBe(RBF_SEQUENCE);
+      expect(input.sequence).toBe(NON_RBF_SEQUENCE);
     });
     expect(psbt.version).toBe(2);
   };

--- a/tests/staking/transactions/stakingTransaction.test.ts
+++ b/tests/staking/transactions/stakingTransaction.test.ts
@@ -1,6 +1,6 @@
 import { address } from "bitcoinjs-lib";
 import { BTC_DUST_SAT } from "../../../src/constants/dustSat";
-import { RBF_SEQUENCE } from "../../../src/constants/psbt";
+import { NON_RBF_SEQUENCE } from "../../../src/constants/psbt";
 import { StakingScripts, stakingTransaction, transactionIdToHash, UTXO } from "../../../src/index";
 import { ObservableStakingScripts } from "../../../src/staking/observable";
 import { TransactionResult } from "../../../src/types/transaction";
@@ -378,7 +378,7 @@ describe.each(testingNetworks)("Transactions - ", (
     ).toBeDefined();
 
     transaction.ins.map((input) => {
-      expect(input.sequence).toBe(RBF_SEQUENCE);
+      expect(input.sequence).toBe(NON_RBF_SEQUENCE);
     });
     expect(transaction.version).toBe(2);
   };


### PR DESCRIPTION
I decide to make the observable staking also Non-RBF to keep it consistent. easier for code maintenance.