### PR TITLE
hotfix : Update slashing amount calculation

### DIFF
--- a/src/staking/transactions.ts
+++ b/src/staking/transactions.ts
@@ -575,7 +575,7 @@ function slashingTransaction(
   const stakingAmount = transaction.outs[outputIndex].value;
   // Slashing rate is a percentage of the staking amount, rounded down to
   // the nearest integer to avoid sending decimal satoshis
-  const slashingAmount = Math.floor(stakingAmount * slashingRate);
+  const slashingAmount = Math.round(stakingAmount * slashingRate);
   if (slashingAmount <= BTC_DUST_SAT) {
     throw new Error("Slashing amount is less than dust limit");
   }


### PR DESCRIPTION
## Hotfix for slashing amount calculation

**Summary**

This PR addresses a critical bug in the slashing amount calculation logic in the JavaScript library, which previously used Math.floor to compute penalty amounts. To align with the reference implementation in Go, we replace Math.floor with Math.round.

**Problem**

If we used some number like 51230, the slashamount will be 2561.5(51230*0.05) and then the core would reject the staking caused by this line

```go
	minSlashingAmount := btcutil.Amount(stakingOutputValue).MulF64(slashingRateFloat64)
	// slashingTx.TxOut[0].Value was made by ts library
	// minSlashingAmount was made by above code
	if btcutil.Amount(slashingTx.TxOut[0].Value) < minSlashingAmount {
		return fmt.Errorf("slashing transaction must slash at least staking output value * slashing rate")
	}
```

and then, we can see this result

```
 error(message: "failed to execute message; message index: 0: slashing transaction must slash at least staking output value * slashing rate: the BTC staking tx is not valid [cosmossdk.io/errors@v1.0.1/errors.go:151] with gas used: \'67661\'")
```

**Solution**

We need to change the rounding from floor in Math to satisfy the condition.
## Reference

**Reference**

ref; https://github.com/babylonlabs-io/babylon/blob/main/btcstaking/staking.go#L344

```go
// MulF64 multiplies an Amount by a floating point value.  While this is not
// an operation that must typically be done by a full node or wallet, it is
// useful for services that build on top of bitcoin (for example, calculating
// a fee by multiplying by a percentage).
func (a Amount) MulF64(f float64) Amount {
	return round(float64(a) * f)
}
```