### PR TITLE
fix: should not fail transaction if output is op_return when finding …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/btc-staking-ts",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol.",
   "module": "dist/index.js",
   "main": "dist/index.cjs",

--- a/src/utils/staking/index.ts
+++ b/src/utils/staking/index.ts
@@ -186,7 +186,11 @@ export const findMatchingTxOutputIndex = (
   network: networks.Network,
 ) => {
   const index = tx.outs.findIndex(output => {
-    return address.fromOutputScript(output.script, network) === outputAddress;
+    try {
+      return address.fromOutputScript(output.script, network) === outputAddress;  
+    } catch (error) {
+      return false;
+    }
   });
 
   if (index === -1) {

--- a/tests/utils/staking/findMatchingTxOutputIndex.test.ts
+++ b/tests/utils/staking/findMatchingTxOutputIndex.test.ts
@@ -1,0 +1,90 @@
+import { Transaction, address } from "bitcoinjs-lib";
+import { findMatchingTxOutputIndex } from "../../../src/utils/staking";
+import { testingNetworks } from "../../helper";
+import { StakingError, StakingErrorCode } from "../../../src/error";
+
+describe.each(testingNetworks)('findMatchingTxOutputIndex', (
+  { network, networkName, datagen: { stakingDatagen: dataGenerator } }
+) => {
+  it(`${networkName} should find the correct output index for a valid address`, () => {
+    // Create a transaction with multiple outputs
+    const tx = new Transaction();
+    const keyPair1 = dataGenerator.generateRandomKeyPair();
+    const keyPair2 = dataGenerator.generateRandomKeyPair();
+    const outputAddress1 = dataGenerator.getAddressAndScriptPubKey(keyPair1.publicKey).nativeSegwit.address;
+    const outputAddress2 = dataGenerator.getAddressAndScriptPubKey(keyPair2.publicKey).nativeSegwit.address;
+    
+    // Add outputs to the transaction
+    tx.addOutput(
+      address.toOutputScript(outputAddress1, network),
+      1000000
+    );
+    tx.addOutput(
+      address.toOutputScript(outputAddress2, network),
+      2000000
+    );
+
+    // Test finding the first output
+    const index1 = findMatchingTxOutputIndex(tx, outputAddress1, network);
+    expect(index1).toBe(0);
+
+    // Test finding the second output
+    const index2 = findMatchingTxOutputIndex(tx, outputAddress2, network);
+    expect(index2).toBe(1);
+  });
+
+  it(`${networkName} should throw an error when no matching output is found`, () => {
+    const tx = new Transaction();
+    const keyPair1 = dataGenerator.generateRandomKeyPair();
+    const keyPair2 = dataGenerator.generateRandomKeyPair();
+    const outputAddress1 = dataGenerator.getAddressAndScriptPubKey(keyPair1.publicKey).nativeSegwit.address;
+    const outputAddress2 = dataGenerator.getAddressAndScriptPubKey(keyPair2.publicKey).nativeSegwit.address;
+    
+    // Add an output with a different address
+    tx.addOutput(
+      address.toOutputScript(outputAddress1, network),
+      1000000
+    );
+
+    // Try to find an address that doesn't exist in the outputs
+    expect(() => {
+      findMatchingTxOutputIndex(tx, outputAddress2, network);
+    }).toThrow(new StakingError(
+      StakingErrorCode.INVALID_OUTPUT,
+      `Matching output not found for address: ${outputAddress2}`
+    ));
+  });
+
+  it(`${networkName} should handle empty transaction outputs`, () => {
+    const tx = new Transaction();
+    const keyPair = dataGenerator.generateRandomKeyPair();
+    const outputAddress = dataGenerator.getAddressAndScriptPubKey(keyPair.publicKey).nativeSegwit.address;
+
+    expect(() => {
+      findMatchingTxOutputIndex(tx, outputAddress, network);
+    }).toThrow(new StakingError(
+      StakingErrorCode.INVALID_OUTPUT,
+      `Matching output not found for address: ${outputAddress}`
+    ));
+  });
+
+  it(`${networkName} should handle no matching address from output scripts`, () => {
+    const tx = new Transaction();
+    const keyPair = dataGenerator.generateRandomKeyPair();
+    const outputAddress = dataGenerator.getAddressAndScriptPubKey(
+      keyPair.publicKey
+    ).nativeSegwit.address;
+
+    tx.addOutput(
+      Buffer.from('OP_RETURN xyz'),
+      1000000
+    );
+
+    expect(() => {
+      findMatchingTxOutputIndex(tx, outputAddress, network);
+    }).toThrow(new StakingError(
+      StakingErrorCode.INVALID_OUTPUT,
+      `Matching output not found for address: ${outputAddress}`
+    ));
+  });
+}); 


### PR DESCRIPTION
This PR is to fix issue on finding the staking output from tx where the OP_RETURN output has higher indexer order than the staking output.
For example a user who try to unbond the staking tx with below scenario:

Scenario 1: Fail
0 OP_RETURN xxxx
1 Staking output address

Scenario 1: Success
0 Staking output address
1 OP_RETURN xxxx

Example https://mempool.space/tx/551fc9785bd0d16f245fb77bfc19259cdf4a608c7f307e3811bcc2c87c3fefd4?mode=details
