### PR TITLE
fix: Peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/btc-staking-ts",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "1.0.1",
-        "@cosmjs/encoding": "^0.33.0"
+        "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
+        "@cosmjs/encoding": "^0.33.0",
+        "bitcoinjs-lib": "6.1.5"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -33,10 +35,6 @@
       },
       "engines": {
         "node": "22.3.0"
-      },
-      "peerDependencies": {
-        "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
-        "bitcoinjs-lib": "6.1.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -649,7 +647,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@bitcoin-js/tiny-secp256k1-asmjs/-/tiny-secp256k1-asmjs-2.2.3.tgz",
       "integrity": "sha512-arFPdEZi9RIiaG76OZswTnAU0KfuiLwGw2VNfD66LKhzlbfOnX1o1WI/GI3qm9UbjG/0QOzZu/KmTNvL79x/DQ==",
-      "peer": true,
       "dependencies": {
         "uint8array-tools": "0.0.7"
       },
@@ -1223,7 +1220,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -1926,8 +1922,7 @@
     "node_modules/base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
-      "peer": true
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1952,14 +1947,12 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "peer": true
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/bip174": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
       "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1969,7 +1962,6 @@
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.5.tgz",
       "integrity": "sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
@@ -2053,7 +2045,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "peer": true,
       "dependencies": {
         "base-x": "^4.0.0"
       }
@@ -2062,7 +2053,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
       "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^5.0.0"
@@ -5863,7 +5853,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
       "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5938,7 +5927,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
       "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -68,9 +68,7 @@
   },
   "dependencies": {
     "@babylonlabs-io/babylon-proto-ts": "1.0.1",
-    "@cosmjs/encoding": "^0.33.0"
-  },
-  "peerDependencies": {
+    "@cosmjs/encoding": "^0.33.0",
     "bitcoinjs-lib": "6.1.5",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonlabs-io/btc-staking-ts",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Library exposing methods for the creation and consumption of Bitcoin transactions pertaining to Babylon's Bitcoin Staking protocol.",
   "module": "dist/index.js",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Moves `bitcoinjs-lib` and `@bitcoin-js/tiny-secp256k1-asmjs` from `peerDependencies ` to `dependencies`