### PR TITLE
fix: pass pop address

### DIFF
--- a/src/staking/manager.ts
+++ b/src/staking/manager.ts
@@ -732,6 +732,7 @@ export class BabylonBtcStakingManager {
     }
 
     this.ee?.emit(channel, {
+      bech32Address,
       type: "proof-of-possession",
     });
 


### PR DESCRIPTION
Adds `baby` address when signing POP, needed for the UI of no blind signing