### PR TITLE
fix: expansion tx staking tx input size is 268 when estimating the fee

### DIFF
--- a/src/constants/fee.ts
+++ b/src/constants/fee.ts
@@ -2,8 +2,12 @@
 export const DEFAULT_INPUT_SIZE = 180;
 // Estimated size of a P2WPKH input in bytes
 export const P2WPKH_INPUT_SIZE = 68;
-// Estimated size of a P2TR input in bytes
+// Estimated size of a P2TR input in bytes. 42vb inputs + 16vb witness
 export const P2TR_INPUT_SIZE = 58;
+// Estimated size of a P2TR input in bytes for staking expansion transactions.
+// This value accounts for the witness size including covenant signatures
+// and is calibrated for a typical covenant quorum of 6 signatures.
+export const P2TR_STAKING_EXPANSION_INPUT_SIZE = 268;
 // Estimated size of a transaction buffer in bytes
 export const TX_BUFFER_SIZE_OVERHEAD = 11;
 // Buffer for estimation accuracy when fee rate <= 2 sat/byte

--- a/src/utils/fee/index.ts
+++ b/src/utils/fee/index.ts
@@ -6,6 +6,7 @@ import {
   OP_RETURN_OUTPUT_VALUE_SIZE,
   OP_RETURN_VALUE_SERIALIZE_SIZE,
   P2TR_INPUT_SIZE,
+  P2TR_STAKING_EXPANSION_INPUT_SIZE,
   TX_BUFFER_SIZE_OVERHEAD,
   WALLET_RELAY_FEE_RATE_THRESHOLD,
   WITHDRAW_TX_BUFFER_SIZE,
@@ -143,8 +144,14 @@ export const getStakingExpansionTxFundingUTXOAndFees = (
     // Calculate the estimated transaction size including:
     // - Base transaction size (additional UTXOs + Outputs)
     // - Previous staking transaction output as the input for the expansion tx
-    // Note: Staking transactions use P2TR (Taproot) format, hence P2TR_INPUT_SIZE
-    const estimatedSize = getEstimatedSize([utxo], outputs) + P2TR_INPUT_SIZE;
+    // Note: Staking transactions use P2TR (Taproot) format,
+    // hence P2TR_STAKING_EXPANSION_INPUT_SIZE accounts for the witness size
+    // including covenant signatures and is calibrated for a typical covenant
+    // quorum of 6 signatures.
+    const estimatedSize = getEstimatedSize(
+      [utxo],
+      outputs,
+    ) + P2TR_STAKING_EXPANSION_INPUT_SIZE;
     
     // Calculate base fee: size * rate + buffer fee for network congestion
     let estimatedFee = estimatedSize * feeRate + rateBasedTxBufferFee(feeRate);

--- a/tests/staking/psbt/stakingExpansionPsbt.test.ts
+++ b/tests/staking/psbt/stakingExpansionPsbt.test.ts
@@ -12,7 +12,7 @@ describe.each(testingNetworks)("Transactions - ", (
   describe.each(Object.values(datagen))("stakingExpansionPsbt", (
     dataGenerator
   ) => {
-    const feeRate = 15;
+    const feeRate = 1;
     const stakerKeyPair = dataGenerator.generateRandomKeyPair();
     const {
       stakingTx: previousStakingTx,

--- a/tests/utils/fee/stakingExpansionTxFee.test.ts
+++ b/tests/utils/fee/stakingExpansionTxFee.test.ts
@@ -94,7 +94,7 @@ describe.each(testingNetworks)("utils - fee - ", (
           outputs,
         );
         
-        expect(result.fee).toBe(253);
+        expect(result.fee).toBe(463);
         expect(result.selectedUTXO).toEqual(availableUTXOs[0]);
       });
 
@@ -117,7 +117,7 @@ describe.each(testingNetworks)("utils - fee - ", (
           outputs,
         );
         
-        expect(result.fee).toBe(243);
+        expect(result.fee).toBe(453);
         expect(result.selectedUTXO).toEqual(availableUTXOs[0]);
       });
 
@@ -127,7 +127,7 @@ describe.each(testingNetworks)("utils - fee - ", (
             txid: dataGenerator.generateRandomTxId(),
             vout: 0,
             scriptPubKey: dataGenerator.generateRandomScriptPubKey(),
-            value: 210, // Just enough to cover fee without change
+            value: 420, // Just enough to cover fee without change
           },
         ];
 
@@ -138,7 +138,7 @@ describe.each(testingNetworks)("utils - fee - ", (
           outputs,
         );
         
-        expect(result.fee).toBe(210); // Without change output, hence smaller
+        expect(result.fee).toBe(420); // Without change output, hence smaller
         expect(result.selectedUTXO).toEqual(availableUTXOs[0]);
       });
 
@@ -148,7 +148,7 @@ describe.each(testingNetworks)("utils - fee - ", (
             txid: dataGenerator.generateRandomTxId(),
             vout: 0,
             scriptPubKey: dataGenerator.generateRandomScriptPubKey(),
-            value: 210 + BTC_DUST_SAT,
+            value: 420 + BTC_DUST_SAT,
           },
         ];
 
@@ -159,7 +159,7 @@ describe.each(testingNetworks)("utils - fee - ", (
           outputs,
         );
         
-        expect(result.fee).toBe(210); // Without change output, hence smaller
+        expect(result.fee).toBe(420); // Without change output, hence smaller
         expect(result.selectedUTXO).toEqual(availableUTXOs[0]);
       });
 
@@ -169,7 +169,7 @@ describe.each(testingNetworks)("utils - fee - ", (
             txid: dataGenerator.generateRandomTxId(),
             vout: 0,
             scriptPubKey: dataGenerator.generateRandomScriptPubKey(),
-            value: 210 + BTC_DUST_SAT + 1, // More than dust threshold
+            value: 420 + BTC_DUST_SAT + 1, // More than dust threshold
           },
         ];
 
@@ -180,7 +180,7 @@ describe.each(testingNetworks)("utils - fee - ", (
           outputs,
         );
 
-        expect(result.fee).toBe(253);
+        expect(result.fee).toBe(463);
         expect(result.selectedUTXO).toEqual(availableUTXOs[0]);
       });
 
@@ -209,7 +209,7 @@ describe.each(testingNetworks)("utils - fee - ", (
 
         // Should select the valid UTXO
         expect(result.selectedUTXO).toEqual(availableUTXOs[1]);
-        expect(result.fee).toEqual(253);
+        expect(result.fee).toEqual(463);
       });
 
       it("should throw error when no valid UTXOs are available", () => {
@@ -268,7 +268,7 @@ describe.each(testingNetworks)("utils - fee - ", (
           1,
           outputs,
         );
-        expect(result.fee).toBe(296);
+        expect(result.fee).toBe(506);
         expect(result.selectedUTXO).toEqual(availableUTXOs[0]);
       });
     });


### PR DESCRIPTION
Fix an bug in the fee estimation of the staking expansion tx where we initially did not take the witness size into consideration.
This PR fixes the issue by increase the input size estimation to 268 vb which would be enough to cover the 6 covenants committee signatures as part of the witness size increase