### PR TITLE
feat: strengthen input validation

### DIFF
--- a/src/staking/transactions.ts
+++ b/src/staking/transactions.ts
@@ -16,11 +16,7 @@ import { REDEEM_VERSION } from "../constants/transaction";
 import { UTXO } from "../types/UTXO";
 import { CovenantSignature } from "../types/covenantSignatures";
 import { PsbtResult, TransactionResult } from "../types/transaction";
-import {
-  isValidBitcoinAddress,
-  isValidNoCoordPublicKey,
-  transactionIdToHash,
-} from "../utils/btc";
+import { isValidBitcoinAddress, transactionIdToHash } from "../utils/btc";
 import {
   getStakingExpansionTxFundingUTXOAndFees,
   getStakingTxInputUTXOsAndFees,
@@ -224,7 +220,7 @@ export function stakingExpansionTransaction(
   if (amount !== previousStakingAmount) {
     throw new Error(
       "Expansion staking transaction amount must be equal to the previous " +
-      "staking amount. Increase of the staking amount is not supported yet.",
+        "staking amount. Increase of the staking amount is not supported yet.",
     );
   }
 
@@ -742,7 +738,8 @@ function slashingTransaction(
   const isString = typeof slashingPkScriptHex === "string";
   const isNonEmpty = isString && slashingPkScriptHex.length > 0;
   const isEvenLength = isNonEmpty && slashingPkScriptHex.length % 2 === 0;
-  const hasHexOnlyChars = isEvenLength && /^[0-9a-fA-F]+$/.test(slashingPkScriptHex);
+  const hasHexOnlyChars =
+    isEvenLength && /^[0-9a-fA-F]+$/.test(slashingPkScriptHex);
   if (!(isString && isNonEmpty && isEvenLength && hasHexOnlyChars)) {
     throw new Error("Invalid slashingPkScriptHex format");
   }
@@ -871,7 +868,7 @@ export const createCovenantWitness = (
   if (covenantSigs.length < covenantQuorum) {
     throw new Error(
       `Not enough covenant signatures. Required: ${covenantQuorum}, ` +
-      `got: ${covenantSigs.length}`,
+        `got: ${covenantSigs.length}`,
     );
   }
   // Filter out the signatures that are not in the params covenants
@@ -895,7 +892,7 @@ export const createCovenantWitness = (
   if (uniqueFilteredCovenantSigs.length < covenantQuorum) {
     throw new Error(
       `Not enough valid covenant signatures. Required: ${covenantQuorum}, ` +
-      `got: ${uniqueFilteredCovenantSigs.length}`,
+        `got: ${uniqueFilteredCovenantSigs.length}`,
     );
   }
 

--- a/src/utils/staking/validation.ts
+++ b/src/utils/staking/validation.ts
@@ -97,16 +97,10 @@ export const validateStakingTxInputData = (
     );
   }
   if (!Number.isInteger(timelock)) {
-    throw new StakingError(
-      StakingErrorCode.INVALID_INPUT,
-      "Invalid timelock",
-    );
+    throw new StakingError(StakingErrorCode.INVALID_INPUT, "Invalid timelock");
   }
   if (!Number.isInteger(feeRate)) {
-    throw new StakingError(
-      StakingErrorCode.INVALID_INPUT,
-      "Invalid fee rate",
-    );
+    throw new StakingError(StakingErrorCode.INVALID_INPUT, "Invalid fee rate");
   }
   if (
     stakingAmountSat < params.minStakingAmountSat ||
@@ -292,8 +286,8 @@ export const validateStakingExpansionCovenantQuorum = (
     throw new StakingError(
       StakingErrorCode.INVALID_INPUT,
       `Staking expansion failed: insufficient covenant quorum. ` +
-      `Required: ${requiredQuorum}, Available: ${activePreviousMembers}. ` +
-      `Too many covenant members have rotated out.`,
+        `Required: ${requiredQuorum}, Available: ${activePreviousMembers}. ` +
+        `Too many covenant members have rotated out.`,
     );
   }
 };

--- a/src/utils/staking/validation.ts
+++ b/src/utils/staking/validation.ts
@@ -89,6 +89,25 @@ export const validateStakingTxInputData = (
   inputUTXOs: UTXO[],
   feeRate: number,
 ) => {
+  // Ensure integer inputs
+  if (!Number.isInteger(stakingAmountSat)) {
+    throw new StakingError(
+      StakingErrorCode.INVALID_INPUT,
+      "Invalid staking amount",
+    );
+  }
+  if (!Number.isInteger(timelock)) {
+    throw new StakingError(
+      StakingErrorCode.INVALID_INPUT,
+      "Invalid timelock",
+    );
+  }
+  if (!Number.isInteger(feeRate)) {
+    throw new StakingError(
+      StakingErrorCode.INVALID_INPUT,
+      "Invalid fee rate",
+    );
+  }
   if (
     stakingAmountSat < params.minStakingAmountSat ||
     stakingAmountSat > params.maxStakingAmountSat
@@ -273,8 +292,8 @@ export const validateStakingExpansionCovenantQuorum = (
     throw new StakingError(
       StakingErrorCode.INVALID_INPUT,
       `Staking expansion failed: insufficient covenant quorum. ` +
-        `Required: ${requiredQuorum}, Available: ${activePreviousMembers}. ` +
-        `Too many covenant members have rotated out.`,
+      `Required: ${requiredQuorum}, Available: ${activePreviousMembers}. ` +
+      `Too many covenant members have rotated out.`,
     );
   }
 };

--- a/tests/staking/createCovenantWitness.test.ts
+++ b/tests/staking/createCovenantWitness.test.ts
@@ -170,4 +170,24 @@ describe("createCovenantWitness", () => {
       ),
     ).toThrow("Not enough valid covenant signatures. Required: 1, got: 0");
   });
+
+  it("should throw when duplicate signatures for the same covenant key are provided", () => {
+    const originalWitness = [Buffer.from("originalWitness1", "utf-8")];
+    const paramsCovenants = [Buffer.from("covenant1", "utf-8")];
+    const duplicatePkHex = "636f76656e616e7431";
+    const covenantSigs = [
+      { btcPkHex: duplicatePkHex, sigHex: "7369676e617475726531" },
+      { btcPkHex: duplicatePkHex, sigHex: "7369676e617475726533" },
+    ];
+    const covenantQuorum = 1;
+
+    expect(() =>
+      createCovenantWitness(
+        originalWitness,
+        paramsCovenants,
+        covenantSigs,
+        covenantQuorum,
+      ),
+    ).toThrow("Duplicate covenant signature for the same public key");
+  });
 });

--- a/tests/staking/transactions/slashingTransaction.test.ts
+++ b/tests/staking/transactions/slashingTransaction.test.ts
@@ -220,6 +220,34 @@ describe.each(testingNetworks)(
               minSlashingFee;
             expect(psbt.txOutputs[1].value).toBe(expectedChangeOutputValue);
           });
+
+          it("should throw for invalid slashingPkScriptHex format (odd length)", () => {
+            expect(() =>
+              slashTimelockUnbondedTransaction(
+                stakingScripts,
+                stakingTx,
+                "abc", // odd length, non-hex
+                slashingRate,
+                minSlashingFee,
+                network,
+                defaultOutputIndex,
+              ),
+            ).toThrow("Invalid slashingPkScriptHex format");
+          });
+
+          it("should throw for invalid slashingPkScriptHex format (non-hex chars)", () => {
+            expect(() =>
+              slashTimelockUnbondedTransaction(
+                stakingScripts,
+                stakingTx,
+                "zz", // non-hex
+                slashingRate,
+                minSlashingFee,
+                network,
+                defaultOutputIndex,
+              ),
+            ).toThrow("Invalid slashingPkScriptHex format");
+          });
         });
 
         describe(`${networkName} slashEarlyUnbondedTransaction - `, () => {
@@ -358,6 +386,32 @@ describe.each(testingNetworks)(
             psbt.txInputs.forEach((input) => {
               expect(input.sequence).toBe(NON_RBF_SEQUENCE);
             });
+          });
+
+          it("should throw for invalid slashingPkScriptHex format (odd length)", () => {
+            expect(() =>
+              slashEarlyUnbondedTransaction(
+                stakingScripts,
+                unbondingTx,
+                "abc",
+                slashingRate,
+                minSlashingFee,
+                network,
+              ),
+            ).toThrow("Invalid slashingPkScriptHex format");
+          });
+
+          it("should throw for invalid slashingPkScriptHex format (non-hex chars)", () => {
+            expect(() =>
+              slashEarlyUnbondedTransaction(
+                stakingScripts,
+                unbondingTx,
+                "zz",
+                slashingRate,
+                minSlashingFee,
+                network,
+              ),
+            ).toThrow("Invalid slashingPkScriptHex format");
           });
         });
       },

--- a/tests/utils/staking/validation.test.ts
+++ b/tests/utils/staking/validation.test.ts
@@ -104,6 +104,42 @@ describe.each(testingNetworks)("validateStakingTxInputData", ({ datagen }) => {
           ),
         ).toThrow("Invalid fee rate");
       });
+
+      it("should throw an error if stakingAmountSat is not an integer", () => {
+        expect(() =>
+          validateStakingTxInputData(
+            params.minStakingAmountSat + 0.5,
+            params.minStakingTimeBlocks,
+            params,
+            validInputUTXOs,
+            feeRate,
+          ),
+        ).toThrow("Invalid staking amount");
+      });
+
+      it("should throw an error if timelock is not an integer", () => {
+        expect(() =>
+          validateStakingTxInputData(
+            params.minStakingAmountSat,
+            params.minStakingTimeBlocks + 0.1,
+            params,
+            validInputUTXOs,
+            feeRate,
+          ),
+        ).toThrow("Invalid timelock");
+      });
+
+      it("should throw an error if feeRate is not an integer", () => {
+        expect(() =>
+          validateStakingTxInputData(
+            params.minStakingAmountSat,
+            params.minStakingTimeBlocks,
+            params,
+            validInputUTXOs,
+            1.1,
+          ),
+        ).toThrow("Invalid fee rate");
+      });
     },
   );
 });
@@ -282,8 +318,8 @@ describe.each(testingNetworks)(
         validateStakingExpansionCovenantQuorum(previousParams, newParams),
       ).toThrow(
         `Staking expansion failed: insufficient covenant quorum. ` +
-          `Required: ${requiredQuorum}, Available: ${covenantNoCoordPks.length - requiredQuorum}. ` +
-          `Too many covenant members have rotated out.`,
+        `Required: ${requiredQuorum}, Available: ${covenantNoCoordPks.length - requiredQuorum}. ` +
+        `Too many covenant members have rotated out.`,
       );
     });
 

--- a/tests/utils/staking/validation.test.ts
+++ b/tests/utils/staking/validation.test.ts
@@ -318,8 +318,8 @@ describe.each(testingNetworks)(
         validateStakingExpansionCovenantQuorum(previousParams, newParams),
       ).toThrow(
         `Staking expansion failed: insufficient covenant quorum. ` +
-        `Required: ${requiredQuorum}, Available: ${covenantNoCoordPks.length - requiredQuorum}. ` +
-        `Too many covenant members have rotated out.`,
+          `Required: ${requiredQuorum}, Available: ${covenantNoCoordPks.length - requiredQuorum}. ` +
+          `Too many covenant members have rotated out.`,
       );
     });
 


### PR DESCRIPTION
Adds input validation: integer checks, covenant signature uniqueness with correct mapping, and strict slashingPkScriptHex validation. Include tests. Prevents malformed inputs, and avoids crashes or invalid transactions.

https://github.com/babylonlabs-io/btc-staking-ts/issues/163