### PR TITLE
fix: add provenance config to releaserc.json and fix OIDC by updating the workflow version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,5 +32,5 @@ jobs:
       publish: true
       publish-command: |
         ./bin/ci_validate_version.sh
-        npm publish --provenance --access public
+        npm publish --provenance
       node-version: 24.2.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
   # Semantic release for main branch
   semantic_release:
     if: github.ref == 'refs/heads/main'
-    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@v0.14.5
+    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@847cd8a6ff9c64e401ce922d12532979d9ac5e93 # v0.14.5
     secrets: inherit
     with:
       run-build: true
@@ -24,7 +24,7 @@ jobs:
   # Manual publish for release branches
   manual_release:
     if: startsWith(github.ref, 'refs/heads/release/v')
-    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@v0.14.5
+    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@847cd8a6ff9c64e401ce922d12532979d9ac5e93 # v0.14.5
     secrets: inherit
     with:
       run-build: true
@@ -32,5 +32,5 @@ jobs:
       publish: true
       publish-command: |
         ./bin/ci_validate_version.sh
-        npm publish --provenance
+        npm publish --provenance --access public
       node-version: 24.2.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   # Semantic release for main branch
   semantic_release:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,9 +11,9 @@ permissions:
   id-token: write
   pull-requests: write
 jobs:
-  # Semantic release for main branch (or manual dispatch for testing)
+  # Semantic release for main branch
   semantic_release:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main'
     uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@99af4c1bde5bca8eb38da101d48ddfa5bf32ba5f # v0.14.7
     secrets: inherit
     with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
   # Semantic release for main branch
   semantic_release:
     if: github.ref == 'refs/heads/main'
-    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@v0.13.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@v0.14.5
     secrets: inherit
     with:
       run-build: true
@@ -24,7 +24,7 @@ jobs:
   # Manual publish for release branches
   manual_release:
     if: startsWith(github.ref, 'refs/heads/release/v')
-    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@v0.13.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@v0.14.5
     secrets: inherit
     with:
       run-build: true
@@ -32,5 +32,5 @@ jobs:
       publish: true
       publish-command: |
         ./bin/ci_validate_version.sh
-        npm publish
+        npm publish --provenance --access public
       node-version: 24.2.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,9 +11,9 @@ permissions:
   id-token: write
   pull-requests: write
 jobs:
-  # Semantic release for main branch
+  # Semantic release for main branch (or manual dispatch for testing)
   semantic_release:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@99af4c1bde5bca8eb38da101d48ddfa5bf32ba5f # v0.14.7
     secrets: inherit
     with:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/npm", { "pkgRoot": ".", "provenance": true }],
+    ["@semantic-release/npm", { "provenance": true }],
     "@semantic-release/github"
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
+    ["@semantic-release/npm", { "pkgRoot": ".", "provenance": true }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
### Description
This PR is solving the issue with our semantic release workflow.

### Context
NPM deprecated classic NPM tokens for security and is leaning towards to OIDC connections which are way more secure.

Source: https://github.com/semantic-release/npm?tab=readme-ov-file#trusted-publishing-for-gitlab-pipelines

### Fixes applied
- Adding provenance to releaserc.json
- Updating workflow to v0.14.7 which contains the changes necessary (delete the dep of a NPM_TOKEN)
